### PR TITLE
Tag all docker images with "latest" tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,4 +47,4 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64
           push: true
-          tags: ghcr.io/blueprintframework/blueprint:${{ github.event.inputs.branch || matrix.branch }}
+          tags: ghcr.io/blueprintframework/blueprint:${{ github.event.inputs.branch || matrix.branch }},ghcr.io/blueprintframework/blueprint:latest


### PR DESCRIPTION
It would be really great if there would be a "latest" tag. I know it's unsafe for production use, but I'd be glad to have it when testing on my home setup.

Resolves #5 