### PR TITLE
Fix healthcheck for mariadb in database service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,11 +57,11 @@ services:
       MYSQL_DATABASE: "panel"
       MYSQL_USER: "pterodactyl"
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
-      interval: 30s
-      timeout: 10s
-      retries: 5
-      start_period: 30s
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      start_period: 10s
+      interval: 10s
+      timeout: 5s
+      retries: 3
     networks:
       - pterodactyl_stack
       # - pterodactyl_nw


### PR DESCRIPTION
The existing health check uses `mysqladmin` which is not installed within the current mariadb:10.5 image.

This replacement healthcheck comes directly from the [MariaDB Website](https://mariadb.com/kb/en/using-healthcheck-sh/)

Suggestion:

You may also want to look into replacing the pinned version with `mariadb:lts` instead (not included in PR)
