### PR TITLE
feat: allow disabling --seed on startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,3 +82,9 @@ autorestart=false
 startsecs=0
 priority=1
 EOF
+
+# Override the default entrypoint script
+COPY entrypoint.sh entrypoint.sh
+RUN chmod +x entrypoint.sh
+ENTRYPOINT [ "/bin/ash", "entrypoint.sh" ]
+CMD [ "supervisord", "-n", "-c", "/etc/supervisord.conf" ]

--- a/classic-docker-compose.yml
+++ b/classic-docker-compose.yml
@@ -67,6 +67,7 @@ services:
       DB_PASSWORD: *db-password
       APP_ENV: "production"
       APP_ENVIRONMENT_ONLY: "false"
+      BOOTSTRAP_SEED_DATABASE: "true" # Comment this line out to disable the --seed flag on php artisan migrate when starting up.
       CACHE_DRIVER: "redis"
       SESSION_DRIVER: "redis"
       QUEUE_DRIVER: "redis"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,6 +108,7 @@ services:
       DB_PASSWORD: *db-password
       APP_ENV: "production" # "production" or "testing"
       APP_ENVIRONMENT_ONLY: "false"
+      BOOTSTRAP_SEED_DATABASE: "true" # Comment this line out to disable the --seed flag on php artisan migrate when starting up.
       CACHE_DRIVER: "redis"
       SESSION_DRIVER: "redis"
       QUEUE_DRIVER: "redis"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,81 @@
+#!/bin/ash -e
+cd /app
+
+mkdir -p /var/log/panel/logs/ /var/log/supervisord/ /var/log/nginx/ /var/log/php7/ \
+  && chmod 777 /var/log/panel/logs/ \
+  && ln -s /app/storage/logs/ /var/log/panel/
+
+## check for .env file and generate app keys if missing
+if [ -f /app/var/.env ]; then
+  echo "external vars exist."
+  rm -rf /app/.env
+  ln -s /app/var/.env /app/
+else
+  echo "external vars don't exist."
+  rm -rf /app/.env
+  touch /app/var/.env
+
+  ## manually generate a key because key generate --force fails
+  if [ -z $APP_KEY ]; then
+     echo -e "Generating key."
+     APP_KEY=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
+     echo -e "Generated app key: $APP_KEY"
+     echo -e "APP_KEY=$APP_KEY" > /app/var/.env
+  else
+    echo -e "APP_KEY exists in environment, using that."
+    echo -e "APP_KEY=$APP_KEY" > /app/var/.env
+  fi
+
+  ln -s /app/var/.env /app/
+fi
+
+echo "Checking if https is required."
+if [ -f /etc/nginx/http.d/panel.conf ]; then
+  echo "Using nginx config already in place."
+  if [ $LE_EMAIL ]; then
+    echo "Checking for cert update"
+    certbot certonly -d $(echo $APP_URL | sed 's~http[s]*://~~g')  --standalone -m $LE_EMAIL --agree-tos -n
+  else
+    echo "No letsencrypt email is set"
+  fi
+else
+  echo "Checking if letsencrypt email is set."
+  if [ -z $LE_EMAIL ]; then
+    echo "No letsencrypt email is set using http config."
+    cp .github/docker/default.conf /etc/nginx/http.d/panel.conf
+  else
+    echo "writing ssl config"
+    cp .github/docker/default_ssl.conf /etc/nginx/http.d/panel.conf
+    echo "updating ssl config for domain"
+    sed -i "s|<domain>|$(echo $APP_URL | sed 's~http[s]*://~~g')|g" /etc/nginx/http.d/panel.conf
+    echo "generating certs"
+    certbot certonly -d $(echo $APP_URL | sed 's~http[s]*://~~g')  --standalone -m $LE_EMAIL --agree-tos -n
+  fi
+  echo "Removing the default nginx config"
+  rm -rf /etc/nginx/http.d/default.conf
+fi
+
+if [[ -z $DB_PORT ]]; then
+  echo -e "DB_PORT not specified, defaulting to 3306"
+  DB_PORT=3306
+fi
+
+## check for DB up before starting the panel
+echo "Checking database status."
+until nc -z -v -w30 $DB_HOST $DB_PORT
+do
+  echo "Waiting for database connection..."
+  # wait for 1 seconds before check again
+  sleep 1
+done
+
+## make sure the db is set up
+echo -e "Migrating and Seeding D.B"
+php artisan migrate --seed --force
+
+## start cronjobs for the queue
+echo -e "Starting cron jobs."
+crond -L /var/log/crond -l 5
+
+echo -e "Starting supervisord."
+exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -70,8 +70,14 @@ do
 done
 
 ## make sure the db is set up
-echo -e "Migrating and Seeding D.B"
-php artisan migrate --seed --force
+echo -e "Running database tasks"
+if [ -n "$BOOTSTRAP_SEED_DATABASE" ]; then
+    echo "Seeding Database: Enabled, running migrate & seed now:"
+    php artisan migrate --seed --force
+else
+    echo "Seeding Database: Disabled, running migrate without seed:"
+    php artisan migrate --force
+fi
 
 ## start cronjobs for the queue
 echo -e "Starting cron jobs."


### PR DESCRIPTION
This PR copies the entrypoint and startup commands from the Pterodactyl repo so we can further customise them (didn't make these changes on pterodactyl/panel because the repo is unmaintained and the PR would never get merged).

In this instance, I customise the entrypoint by only running `--seed` during `php artisan migrate` if the environment variable to do so exists. This allows people like me who don't want `--seed` every time to remove it in our docker compose files.

I've added the variable as a default for backwards compatibility, so all you need to do is remove the env var if you don't want it to --seed.

I thought about a few ways to do this, including the ability to just pass `--force --seed` as a value to an environment variable and then doing something like `php artisan migrate $DB_BOOTSTRAP_FLAGS` so that it can be fully customised but this feels like more of a security concern than a feature, so I went with the hardcoded ability to remove --seed instead, and just run `php artisan migrate --force` if the variable isn't provided.

Any feedback lmk!